### PR TITLE
Run container as numeric user

### DIFF
--- a/diego-docker-app-custom/Dockerfile
+++ b/diego-docker-app-custom/Dockerfile
@@ -1,8 +1,8 @@
 FROM busybox
 MAINTAINER https://github.com/cloudfoundry-incubator/diego-dockerfiles
 
-RUN adduser -D -s /bin/sh dockeruser
-USER dockeruser
+RUN adduser -D -s /bin/sh dockeruser --uid 1000
+USER 1000
 
 ENV VCAP_APPLICATION {}
 ENV BAD_QUOTE \'


### PR DESCRIPTION
We @cloudfoundry/eirini  are running cats to validate feature parity with Diego. Recently we introduced some pod security policies that check that the container uid/gid is not 0, i.e. the containers are unprivileged. It turns out that the Kubernetes Pod Security Policy can only validate against numeric user ids, which makes sense because the PSP kicks in before the container is run. Some docker related CATS started failing after we introduced those PSPs and this change fixes that. I think it should also still work in the Diego context.