### PR TITLE
Explicitly set diego-docker-app USER

### DIFF
--- a/diego-docker-app/Dockerfile
+++ b/diego-docker-app/Dockerfile
@@ -15,4 +15,7 @@ WORKDIR /myapp
 
 RUN adduser -D vcap
 
+# set user to 'nobody' so that it is non-root
+USER 65534
+
 CMD ["dockerapp"]


### PR DESCRIPTION
## Please provide the following information:

### What is this change about?

Sets the diego-docker-app user to 'nobody' so that the container can be run on Kubernetes clusters that have the [`MustRunAsNonRoot` security policy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups).

Alternatively we could explicitly make a new user with a static UID and set it to that.

### What problem it is trying to solve?

This allows CATS to be run with the same Docker test app in both CF for VMs and CF on Kubernetes contexts.

### What is the impact if the change is not made?

We will need to maintain a separate "diego-docker-app" Dockerfile for Kubernetes or change the CATs to use a different app.

### Please provide any contextual information.

Slack discussion: https://cloudfoundry.slack.com/archives/CH9LF6V1P/p1602865303312100

### Tag your pair, your PM, and/or team!

@jamespollard8 @davewalter